### PR TITLE
grpc.io: use linkTitle instead of short_title

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,12 +1,12 @@
 {{/* grpc-docsy file override */ -}}
-{{ if not .Parent.IsHome -}}
+{{ if .Parent.IsHome -}}
+<div class="l-no-breadcrumb"></div>
+{{ else -}}
 <nav aria-label="breadcrumb" class="d-print-none">
 	<ol class="breadcrumb spb-1">
 		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
 	</ol>
 </nav	>
-{{ else -}}
-<div class="l-no-breadcrumb"></div>
 {{ end -}}
 
 {{ define "breadcrumbnav" }}
@@ -19,12 +19,6 @@
 {{ end }}
 {{ $isActive :=  eq .p1 .p2  }}
 <li class="breadcrumb-item{{ if $isActive }} active{{ end }}" {{ if $isActive }}aria-current="page"{{ end }}>
-	<a href="{{ .p1.Permalink }}">
-		{{if isset .p1.Params "short_title" }}
-			{{ .p1.Params.short_title }}
-		{{ else }}
-			{{ .p1.LinkTitle }}
-		{{ end }}
-	</a>
+	<a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
 </li>
 {{ end -}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,3 +1,4 @@
+{{/* grpc-docsy file override */ -}}
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
@@ -36,13 +37,7 @@
 {{ $sid := $s.RelPermalink | anchorize }}
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">
-      {{ if isset $s.Params "short_title" }}
-        {{ $s.Params.short_title }}
-      {{ else }}
-        {{ $s.LinkTitle }}
-      {{ end }}
-    </a>
+    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
   </li>
   <ul>
     <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
@@ -56,14 +51,8 @@
           {{ $isRedirected :=  findRE "^/docs/(languages|platforms)/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
           {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
           <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}" {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}>
-            {{ if isset .Params "short_title" }}
-              {{ .Params.short_title }}
-            {{ else }}
-              {{ .LinkTitle }}
-            {{ end }}
-            {{ if $isExternal -}}
-              <i class="fas fa-external-link-alt"></i>
-            {{- end -}}
+            {{- .LinkTitle }}
+            {{ if $isExternal }}<i class="fas fa-external-link-alt"></i>{{ end -}}
           </a>
         {{ else }}
           {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -51,7 +51,7 @@
           {{ $isRedirected :=  findRE "^/docs/(languages|platforms)/.+?/(api|daily-builds)(/.*)?$" .RelPermalink -}}
           {{ $isExternal := or (hasPrefix .RelPermalink "http") $isRedirected -}}
           <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}" {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}>
-            {{- .LinkTitle }}
+            {{- .LinkTitle -}}
             {{ if $isExternal }}<i class="fas fa-external-link-alt"></i>{{ end -}}
           </a>
         {{ else }}


### PR DESCRIPTION
- Contributes to https://github.com/grpc/grpc.io/issues/820
- No changes to generated grpc.io website files, modulo whitespace -- as trivially checked over the first commit. (The second commit obviously only trims whitespace).