### PR TITLE
including gtm script

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,6 +5,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "gtm-noscript.html" . }}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,6 @@
+<!-- Google Tag Manager -->
+{{ partial "gtm.html" . }}
+  <!-- End Google Tag Manager -->
 {{/* grpc-docsy file override */ -}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Including GTM script in head.html and baseof.html to track the events across all pages.